### PR TITLE
Segmentation Fault with optional callable

### DIFF
--- a/tests/callables_work.phpt
+++ b/tests/callables_work.phpt
@@ -36,6 +36,15 @@ function global_fn() {
 }
 
 /**
+* @param string
+* @param callable|void
+* @return string
+*/
+function accept_optional_callable($string, $fn = null) {
+	return $string;
+}
+
+/**
 * @param callable
 * @return string
 */
@@ -48,6 +57,7 @@ echo accept_callables($fn);
 echo accept_callables(new Invokable());
 echo accept_callables([new Targetable(), "go"]);
 echo accept_callables("global_fn");
+echo accept_optional_callable("test string\n");
 
 accept_callables(["NotAClass", "hey"]);
 
@@ -58,6 +68,7 @@ closure works
 invokable works
 array callable syntax works
 global functions work
+test string
 
 (.*)Wrong type encountered for argument 1 of function accept_callables, was expecting a callable but got a array
 (.*)


### PR DESCRIPTION
When using an optional param that is supposed to be callable, I'm getting "Segmentation fault: 11"

Again, I don't know any C, but the test case in this pull request does reproduce always on my machine. I'm using Mac OS X Mavericks with homebrew php. Here's the summary wall from `make test`:

 =====================================================================
 PHP         : /usr/local/Cellar/php55/5.5.8/bin/php 
 PHP_SAPI    : cli
 PHP_VERSION : 5.5.8
 ZEND_VERSION: 2.5.0
 PHP_OS      : Darwin - Darwin CAP-MBP-45.local 13.0.0 Darwin Kernel Version 13.0.0: Thu Sep 19 22:22:27 PDT 2013; root:xnu-2422.1.72~6/RELEASE_X86_64 x86_64
 INI actual  : /Volumes/Sources/vendors/augmented_types-git/tmp-php.ini
 More .INIs  :  
 CWD         : /Volumes/Sources/vendors/augmented_types-git
 Extra dirs  : 
 VALGRIND    : Not used
 =====================================================================

Let me know if there's any more info I can give you to help with this.
